### PR TITLE
grant mkdocs job ability to push to pages branch

### DIFF
--- a/.github/workflows/push-mkdocs-deploy.yaml
+++ b/.github/workflows/push-mkdocs-deploy.yaml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+permissions:
+  pages: write
 
 jobs:
   deploy:


### PR DESCRIPTION
Fixes ability for workflow to push to github pages branch.