### PR TITLE
Script to publish mkdocs

### DIFF
--- a/.github/workflows/push-mkdocs-deploy.yaml
+++ b/.github/workflows/push-mkdocs-deploy.yaml
@@ -37,11 +37,6 @@ jobs:
       # install project
       - name: Install project
         run: poetry install --no-interaction
-      # activate venv
-      - name: Activate virtualenv
-        run: |
-            source .venv/bin/activate
-            echo PATH=$PATH >> $GITHUB_ENV
       # build and publish docs to github pages
       - name: Publish docs to github pages
-        run: mkdocs gh-deploy --force --clean --verbose
+        run: ./tools/publish-mkdocs.sh

--- a/docs/dev/release-process.md
+++ b/docs/dev/release-process.md
@@ -17,7 +17,8 @@ The release workflow follows:
 ### publishing docs
 
 The GitHub Actions workflow at `.github/workflows/push-mkdocs-deploy.yaml` is run when a PR is merged to `main`
-which builds and publishes documentation to [github pages][gh-pages] using [`mkdocs`][mkdocs]. 
+which builds and publishes documentation to [github pages][gh-pages] using [`mkdocs`][mkdocs] via running
+the script at `tools/publish-mkdocs.sh`.
 
 [gh-pages]: https://coffeemancy.github.io/snirk
 [mkdocs]: https://www.mkdocs.org

--- a/tools/publish-mkdocs.sh
+++ b/tools/publish-mkdocs.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# Script to publish mkdocs to Github Pages.
+#
+# Based on:
+#   https://github.com/mhausenblas/mkdocs-deploy-gh-pages/blob/master/action.sh
+
+set -euo pipefail
+
+SNIRK_VENV="${SNIRK_VENV:-.venv/snirk}"
+
+# make sure not being run as root or with "sudo"
+if (( EUID == 0 )); then
+  echo "Do not run this script as root/sudo."
+  exit 1
+fi
+
+# try to activate snirk virtualenv, if not running in a venv
+if [[ -z "${VIRTUAL_ENV:-}" ]]; then
+  if [[ -n "${SNIRK_VENV}" ]] && [[ -d "${SNIRK_VENV}" ]]; then
+    echo "Activating venv: ${SNIRK_VENV}"
+    # shellcheck disable=SC1091
+    source "${SNIRK_VENV}/bin/activate" || (echo "Failed to activate venv: ${SNIRK_VENV}" && exit 1)
+  else
+    echo "Not running in virtualenv and ${SNIRK_VENV} does not exist!"
+    exit 1
+  fi
+fi
+
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+  echo "Using GITHUB_TOKEN..."
+  remote_repo="https://x-access-token:${GITHUB_TOKEN}@github.com/coffeemancy/snirk.git"
+else
+  remote_repo="$(git remote get-url origin)"
+fi
+
+# create a new remote "mkdocspush", if doesn't exist
+if ! git remote | grep mkdocspush; then
+  if [ -z "${remote_repo}" ]; then
+    echo "Could not determine remote repo to use!"
+    exit 1
+  fi
+  echo "Adding mkdocspush remote..."
+  git remote add mkdocspush "${remote_repo}"
+fi
+
+echo "Publishing mkdocs..."
+mkdocs gh-deploy --force --clean --verbose --remote-name mkdocspush


### PR DESCRIPTION
Still working on getting automation to publish docs to gh-pages working.

This adds a new script (`tools/publish-mkdocs.sh`) (updating workflow to use it), which,  when `GITHUB_TOKEN` is specified, use that via x-access-token for remote. This _should_ pass on permissions granted from job (i.e. pages writing).

## Updates

### Developer-Facing

* `tools/publish-mkdocs.sh`: script to publish mkdocs gh-pages.

