### PR TITLE
add protobuf to base dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.11"
 grpcio = "^1.60.1"
+protobuf = "^4.25.3"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.2.0"


### PR DESCRIPTION
Found when trying to install wheel (built with `poetry build`) that was missing protobuf from dependencies (it is installed in dev dependencies). This adds it there.